### PR TITLE
core/vm, evmc: fix evmc vaildation tests

### DIFF
--- a/core/vm/evmc.go
+++ b/core/vm/evmc.go
@@ -316,7 +316,7 @@ func (evm *EVMC) Run(contract *Contract, input []byte, readOnly bool) (ret []byt
 
 func (evm *EVMC) CanRun(code []byte) bool {
 	cap := evmc.CapabilityEVM1
-	wasmPreamble := []byte("\x00asm\x01\x00\x00\x00")
+	wasmPreamble := []byte("\x00asm")
 	if bytes.HasPrefix(code, wasmPreamble) {
 		cap = evmc.CapabilityEWASM
 	}


### PR DESCRIPTION
This fixes all the `validate*` errors in EWASM tests. It has been decided that `CanRun` will accept every contract that has the WASM magic number.