### PR TITLE
core/vm, evmc: fix max codesize test

### DIFF
--- a/core/vm/evmc.go
+++ b/core/vm/evmc.go
@@ -311,6 +311,14 @@ func (evm *EVMC) Run(contract *Contract, input []byte, readOnly bool) (ret []byt
 		panic(fmt.Sprintf("EVMC VM internal error: %s", evmcError.Error()))
 	}
 
+	/* Bon il faut que je formalise tout ca */
+	// if len(output) > 100 {
+	// 	if err != errExecutionReverted {
+	// 		contract.UseGas(uint64(gasLeft))
+	// 	}
+	// 	err = errMaxCodeSizeExceeded
+	// }
+
 	return output, err
 }
 


### PR DESCRIPTION
This should fix the last broken test. A check for the maximum code size was missing from the interpreter code.